### PR TITLE
feature fifo queue for sqs

### DIFF
--- a/api/shop/internal/library/sqs_client/models.go
+++ b/api/shop/internal/library/sqs_client/models.go
@@ -2,6 +2,7 @@ package sqs_client
 
 import (
 	"math/rand/v2"
+	"strconv"
 )
 
 type PurchaseStatus string
@@ -33,4 +34,9 @@ func GetRandomPurchaseStatus() PurchaseStatus {
 
 	randomIndex := rand.IntN(len(statuses))
 	return statuses[randomIndex]
+}
+
+// PurchaseQueueMessage: uint64型のuser_idをstring型に変換するメソッド
+func (pqm *PurchaseQueueMessage) GetUIDString() string {
+	return strconv.FormatUint(pqm.UserID, 10)
 }

--- a/api/shop/internal/library/sqs_client/sqs.go
+++ b/api/shop/internal/library/sqs_client/sqs.go
@@ -46,8 +46,10 @@ func (c *SQSClient) SendPurchaseMessage(ctx context.Context, queueURL string, ms
 	}
 
 	_, err = c.Client.SendMessage(ctx, &sqs.SendMessageInput{
-		QueueUrl:    aws.String(queueURL),
-		MessageBody: aws.String(string(msgBody)),
+		QueueUrl:       aws.String(queueURL),
+		MessageBody:    aws.String(string(msgBody)),
+		MessageGroupId: aws.String(msg.GetUIDString()), // NOTE: FIFOキューの場合は必須
+		// MessageDeduplicationId: aws.String("deduplicationId"), // NOTE: FIFOキューの場合、リソース作成時に `content_based_deduplication = true` を指定していない場合は必須
 	})
 	if err != nil {
 		return fmt.Errorf("failed to send message to SQS: %w", err)

--- a/batch/push_notification/internal/handler/handler.go
+++ b/batch/push_notification/internal/handler/handler.go
@@ -25,6 +25,9 @@ func PushNotificationHandler(job usecase.Job) SQSEventJob {
 		*/
 
 		for _, record := range sqsEvent.Records {
+
+			slog.InfoContext(ctx, "push notification handler process started", slog.Any("record body", record.Body))
+
 			var message models.PurchaseQueueMessage
 			if err := json.Unmarshal([]byte(record.Body), &message); err != nil {
 				slog.ErrorContext(ctx, "failed to unmarshal message", slog.String("error", err.Error()))

--- a/batch/push_notification/internal/usecase/send_push_notification_purchase_completed.go
+++ b/batch/push_notification/internal/usecase/send_push_notification_purchase_completed.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (j *Job) SendPushNotificationPurchaseCompleted(ctx context.Context, message models.PurchaseQueueMessage) error {
-	slog.InfoContext(ctx, "send push notification purchase completed...")
+	slog.InfoContext(ctx, "send push notification purchase completed usecase processing")
 
 	// push通知送信したいけどアプリないのでLINE Message APIを利用する。
 

--- a/infra/service/batch/push_notification/lambda.tf
+++ b/infra/service/batch/push_notification/lambda.tf
@@ -10,7 +10,7 @@ resource "aws_lambda_function" "push_notification_batch" {
   vpc_config {
     ipv6_allowed_for_dual_stack = false
     security_group_ids          = [aws_security_group.push_notification_batch.id]
-    subnet_ids                = data.terraform_remote_state.network.outputs.vpc.private_subnet_ids
+    subnet_ids                  = data.terraform_remote_state.network.outputs.vpc.private_subnet_ids
   }
 
   lifecycle {
@@ -42,8 +42,11 @@ resource "aws_lambda_event_source_mapping" "push_notification_batch" {
 
   # Lambdaは20秒間待機し、その間に最大5件のメッセージを集める
   # 待機時間が経過する前に5件集まった場合即座に処理を開始するが、20秒経過したら集まったメッセージ数に関わらず処理が始まる
-  maximum_batching_window_in_seconds = 20
-  batch_size                         = 5
+  batch_size = 5
+  # maximum_batching_window_in_seconds = 20
+
+  # NOTE: `maximum_batching_window_in_seconds` はキューのタイプを標準キューで設定している場合にのみ設定が可能、FIFOにしている場合は設定不可
+  # DOC: https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/services-sqs-configure.html
 
   # 送信されるメッセージにおけるフィルター処理を定義することができる
   # DLQへの受け渡しの挙動を検証したいためフィルタリング設定は無効化する

--- a/infra/sqs/push_notification/sqs.tf
+++ b/infra/sqs/push_notification/sqs.tf
@@ -6,6 +6,9 @@ resource "aws_sqs_queue" "push_notification_queue" {
   # FIFO Queue として定義（順序、及び重複制御を有効にする）
   fifo_queue = true
 
+  # content-basedな重複排除を有効化、明示的な MessageDeduplicationId の指定を省略可能にする（本文のSHA-256がIDとして扱われる）
+  content_based_deduplication = true
+
   # 最大メッセージサイズ
   max_message_size = 256 * 1024 # 256 KiB
 

--- a/infra/sqs/push_notification/sqs.tf
+++ b/infra/sqs/push_notification/sqs.tf
@@ -5,13 +5,13 @@ resource "aws_sqs_queue" "push_notification_queue" {
   fifo_queue = false
 
   # 最大メッセージサイズ
-  max_message_size = local.queue_max_message_size
+  max_message_size = 256 * 1024 # 256 KiB
 
   # キューの可視性タイムアウト。秒単位で設定。（指定した期間中は他のコンシューマーはキューを参照することができない）
-  visibility_timeout_seconds = local.queue_visibility_timeout_seconds
+  visibility_timeout_seconds = 5 * 60 # 5min timeout
 
   # メッセージの保持時間、秒単位で設定
-  message_retention_seconds = local.queue_message_retention_seconds
+  message_retention_seconds = 2 * 24 * 60 * 60 # 2day
 
   # キュー内の全メッセージの配送を遅延させる時間、秒単位で設定。（30秒で設定した場合、キューに送信してもLambda30秒間はこのキューを見ることができない。※0の場合は即時配信となる）
   delay_seconds = 0
@@ -27,7 +27,7 @@ resource "aws_sqs_queue" "push_notification_queue" {
     deadLetterTargetArn = aws_sqs_queue.push_notification_dlq.arn
 
     # リトライ回数の設定。メッセージが繰り返し処理に失敗する場合に、無限ループを防ぐ
-    maxReceiveCount = local.max_receive_count
+    maxReceiveCount = 3
   })
 
   tags = {
@@ -41,9 +41,9 @@ resource "aws_sqs_queue" "push_notification_queue" {
 resource "aws_sqs_queue" "push_notification_dlq" {
   name                       = "${local.fqn}-dlq"
   fifo_queue                 = false
-  max_message_size           = local.dlq_max_message_size
-  visibility_timeout_seconds = local.dlq_visibility_timeout_seconds
-  message_retention_seconds  = local.dlq_message_retention_seconds
+  max_message_size           = 256 * 1024       # 256 KiB
+  visibility_timeout_seconds = 5 * 60           # 5min timeout
+  message_retention_seconds  = 1 * 24 * 60 * 60 # 1day
   delay_seconds              = 0
   receive_wait_time_seconds  = 0
   sqs_managed_sse_enabled    = false

--- a/infra/sqs/push_notification/tfvars/stg.tfvars
+++ b/infra/sqs/push_notification/tfvars/stg.tfvars
@@ -1,16 +1,3 @@
 env       = "stg"
 project   = "async-serverless-app"
 feature   = "push-notification"
-
-queue_config = {
-  max_message_size_kb        = 256
-  visibility_timeout_minutes = 5 # 可視性タイムアウトの時間（分）
-  message_retention_days     = 4 # メッセージの保持期間（日）
-  max_receive_count          = 3 # リトライ回数
-}
-
-dlq_config = {
-  max_message_size_kb        = 256
-  visibility_timeout_minutes = 5
-  message_retention_days     = 7
-}

--- a/infra/sqs/push_notification/variables.tf
+++ b/infra/sqs/push_notification/variables.tf
@@ -16,45 +16,6 @@ variable "feature" {
   default     = "push-notification"
 }
 
-variable "queue_config" {
-  description = "The push notification queue config"
-  type = object({
-    max_message_size_kb        = number
-    visibility_timeout_minutes = number
-    message_retention_days     = number
-    max_receive_count          = number
-  })
-  default = {
-    max_message_size_kb        = 256
-    visibility_timeout_minutes = 15
-    message_retention_days     = 4
-    max_receive_count          = 5
-  }
-}
-
-variable "dlq_config" {
-  description = "The push notification dlq config"
-  type = object({
-    max_message_size_kb        = number
-    visibility_timeout_minutes = number
-    message_retention_days     = number
-  })
-  default = {
-    max_message_size_kb        = 256
-    visibility_timeout_minutes = 15
-    message_retention_days     = 7
-  }
-}
-
 locals {
   fqn = "${var.env}-${var.feature}"
-
-  queue_max_message_size           = var.queue_config.max_message_size_kb * 1024
-  queue_visibility_timeout_seconds = var.queue_config.visibility_timeout_minutes * 60
-  queue_message_retention_seconds  = var.queue_config.message_retention_days * 24 * 60 * 60
-  max_receive_count                = var.queue_config.max_receive_count
-
-  dlq_max_message_size           = var.dlq_config.max_message_size_kb * 1024
-  dlq_visibility_timeout_seconds = var.dlq_config.visibility_timeout_minutes * 60
-  dlq_message_retention_seconds  = var.dlq_config.message_retention_days * 24 * 60 * 60
 }


### PR DESCRIPTION
- **feature gem api ecr (#22)**
- **feature gem api lambda resource (#23)**
- **feature update gem purchase api use dynamodb (#21)**
- **feature gem api to dynamodb (#24)**
- **feature dynamodb table schemas (#25)**
- **fix dynamodb infra resource (#26)**
- **add slack message ecr infra resource (#27)**
- **feature slack message batch service (#28)**
- **add lambda resource's (#29)**
- **feature/dynamodb stream resource (#30)**
- **feature slack message batch dlq (#31)**
- **feature send slack message batch get secret (#32)**
- **feature sqs vpc endpoint for vpc lambda (#33)**
- **fix/private network arc (#34)**
- **remove variables parameter**
- **change queue type standard to fifo**
- **disable `maximum_batching_window_in_seconds` param**
- **add content based deduplication params for sqs resource**
- **fix sqs send message client (message group id)**
- **add slog for handler**
